### PR TITLE
remove CM if ImageBuild is not created

### DIFF
--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -135,43 +135,74 @@ func main() {
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
+    ctx := context.Background()
 
-	c, err := initializeBuildClient()
-	if err != nil {
-		handleError(err)
-	}
+    c, err := initializeBuildClient()
+    if err != nil {
+        handleError(err)
+    }
 
-	if err := validateBuildRequirements(); err != nil {
-		handleError(err)
-	}
+    if err := validateBuildRequirements(); err != nil {
+        handleError(err)
+    }
 
-	configMapName, manifestData, err := setupManifestConfigMap(ctx, c, buildName, namespace, manifest)
-	if err != nil {
-		handleError(err)
-	}
+    var configMapName string
+    var manifestData []byte
 
-	if err := addCustomDefinitionsToConfigMap(ctx, c, configMapName, namespace, customDefs); err != nil {
-		handleError(err)
-	}
+    configMapName, manifestData, err = setupManifestConfigMap(ctx, c, buildName, namespace, manifest)
+    if err != nil {
+        handleError(err)
+    }
 
-	imageBuild, err := createImageBuild(ctx, c, buildName, namespace, configMapName, manifestData)
-	if err != nil {
-		handleError(err)
-	}
+    needsCleanup := true
+    defer func() {
+        if needsCleanup {
+            fmt.Printf("Cleaning up ConfigMap %s due to incomplete operation\n", configMapName)
+            deleteCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+            defer cancel()
 
-	if err := handleLocalFileUploads(ctx, c, namespace, imageBuild, manifestData); err != nil {
-		handleError(err)
-	}
+            configMap := &corev1.ConfigMap{
+                ObjectMeta: metav1.ObjectMeta{
+                    Name:      configMapName,
+                    Namespace: namespace,
+                },
+            }
 
-	fmt.Printf("ImageBuild %s created successfully in namespace %s\n", imageBuild.Name, namespace)
+            if delErr := c.Delete(deleteCtx, configMap); delErr != nil {
+                fmt.Printf("Warning: Failed to clean up ConfigMap: %v\n", delErr)
+            }
+        }
+    }()
 
-	if waitForBuild {
-		if err := handleBuildCompletion(c, imageBuild); err != nil {
-			handleError(err)
-		}
-	}
+    if err := addCustomDefinitionsToConfigMap(ctx, c, configMapName, namespace, customDefs); err != nil {
+        handleError(err)
+    }
+
+    imageBuild, err := createImageBuild(ctx, c, buildName, namespace, configMapName, manifestData)
+    if err != nil {
+        handleError(err)
+    }
+
+    // Update ownership in ConfigMap
+    if err := updateConfigMapOwnership(ctx, c, configMapName, namespace, imageBuild); err != nil {
+        handleError(err)
+    }
+
+    needsCleanup = false
+
+    if err := handleLocalFileUploads(ctx, c, namespace, imageBuild, manifestData); err != nil {
+        handleError(err)
+    }
+
+    fmt.Printf("ImageBuild %s created successfully in namespace %s\n", imageBuild.Name, namespace)
+
+    if waitForBuild {
+        if err := handleBuildCompletion(c, imageBuild); err != nil {
+            handleError(err)
+        }
+    }
 }
+
 
 func createImageBuild(ctx context.Context, c client.Client, name, ns, configMapName string, manifestData []byte) (*automotivev1.ImageBuild, error) {
 	localFileRefs, err := findLocalFileReferences(string(manifestData))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced error management during the build process to ensure temporary resources are automatically cleaned up in the event of errors. This update improves overall system stability and reliability. 
	- Introduced a new operation to update the ownership of the ConfigMap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->