### PR TITLE
Expose artifacts route when user specify in the request

### DIFF
--- a/api/v1/imagebuild_types.go
+++ b/api/v1/imagebuild_types.go
@@ -64,6 +64,9 @@ type ImageBuildSpec struct {
 
 	// InputFilesServer indicates if there's a server for files referenced locally in the manifest
 	InputFilesServer bool `json:"inputFilesServer,omitempty"`
+
+	// ArtifactsRoute indicates if expose the pod route for downloading artifacts
+	ArtifactsRoute bool `json:"artifactsRoute,omitempty"`
 }
 
 // Publishers defines the configuration for artifact publishing
@@ -106,6 +109,9 @@ type ImageBuildStatus struct {
 
 	// TaskRunName is the name of the active TaskRun for this build
 	TaskRunName string `json:"taskRunName,omitempty"`
+
+	// ArtifactURL is the route URL created to expose the artifacts
+	ArtifactURL string `json:"artifactURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -42,6 +42,10 @@ spec:
               architecture:
                 description: Architecture specifies the target architecture
                 type: string
+              artifactsRoute:
+                description: ArtifactsRoute indicates if expose the pod route for
+                  downloading artifacts
+                type: boolean
               automativeOSBuildImage:
                 description: AutomativeOSBuildImage specifies the image to use for
                   building
@@ -114,6 +118,9 @@ spec:
               artifactPath:
                 description: ArtifactPath is the path inside the PVC where the artifact
                   is stored
+                type: string
+              artifactURL:
+                description: ArtifactURL is the route URL created to expose the artifacts
                 type: string
               completionTime:
                 description: CompletionTime is when the build finished

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,7 @@ rules:
   - persistentvolumeclaims
   - pods
   - serviceaccounts
+  - services
   verbs:
   - create
   - delete
@@ -91,6 +92,18 @@ rules:
   - pipelines
   - taskruns
   - tasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
   verbs:
   - create
   - delete


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled an optional setting to expose a download route for image build artifacts.
  - Updated command output to display the artifact access URL when the feature is active.
  - Improved configuration supporting streamlined artifact download handling and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->