### PR TITLE
use tagged automotive image builder container image

### DIFF
--- a/api/v1/imagebuild_types.go
+++ b/api/v1/imagebuild_types.go
@@ -44,8 +44,8 @@ type ImageBuildSpec struct {
 	// StorageClass is the name of the storage class to use for the build PVC
 	StorageClass string `json:"storageClass,omitempty"`
 
-	// AutomativeOSBuildImage specifies the image to use for building
-	AutomativeOSBuildImage string `json:"automativeOSBuildImage,omitempty"`
+	// AutomotiveImageBuilder specifies the image to use for building
+	AutomotiveImageBuilder string `json:"automotiveImageBuilder,omitempty"`
 
 	// ManifestConfigMap specifies the name of the ConfigMap containing the manifest configuration
 	ManifestConfigMap string `json:"manifestConfigMap,omitempty"`

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -57,25 +57,25 @@ func (pr *progressReporter) Write(p []byte) (int, error) {
 }
 
 var (
-	kubeconfig    string
-	namespace     string
-	imageBuildCfg string
-	manifest      string
-	buildName     string
-	distro        string
-	target        string
-	architecture  string
-	exportFormat  string
-	mode          string
-	osbuildImage  string
-	storageClass  string
-	outputDir     string
-	timeout       int
-	waitForBuild  bool
-	download      bool
-	exposeRoute   bool
-	customDefs    []string
-	followLogs    bool
+	kubeconfig             string
+	namespace              string
+	imageBuildCfg          string
+	manifest               string
+	buildName              string
+	distro                 string
+	target                 string
+	architecture           string
+	exportFormat           string
+	mode                   string
+	automotiveImageBuilder string
+	storageClass           string
+	outputDir              string
+	timeout                int
+	waitForBuild           bool
+	download               bool
+	exposeRoute            bool
+	customDefs             []string
+	followLogs             bool
 )
 
 func main() {
@@ -121,7 +121,7 @@ func main() {
 	buildCmd.Flags().StringVar(&architecture, "arch", "arm64", "architecture (amd64, arm64)")
 	buildCmd.Flags().StringVar(&exportFormat, "export-format", "image", "export format (image, qcow2)")
 	buildCmd.Flags().StringVar(&mode, "mode", "image", "build mode")
-	buildCmd.Flags().StringVar(&osbuildImage, "osbuild-image", "quay.io/centos-sig-automotive/automotive-image-builder:latest", "automotive osbuild image")
+	buildCmd.Flags().StringVar(&automotiveImageBuilder, "automotive-image-builder", "quay.io/centos-sig-automotive/automotive-image-builder:1.0.0", "container image for automotive-image-builder")
 	buildCmd.Flags().StringVar(&storageClass, "storage-class", "", "storage class for build PVC")
 	buildCmd.Flags().IntVar(&timeout, "timeout", 60, "timeout in minutes when waiting for build completion")
 	buildCmd.Flags().BoolVarP(&waitForBuild, "wait", "w", false, "wait for the build to complete")
@@ -259,7 +259,7 @@ func createImageBuild(ctx context.Context, c client.Client, name, ns, configMapN
 			Architecture:           architecture,
 			ExportFormat:           exportFormat,
 			Mode:                   mode,
-			AutomativeOSBuildImage: osbuildImage,
+			AutomotiveImageBuilder: automotiveImageBuilder,
 			StorageClass:           storageClass,
 			ServeArtifact:          serveArtifact,
 			ServeExpiryHours:       24,

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_automotivedevs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_automotivedevs.yaml
@@ -48,6 +48,11 @@ spec:
                       MemoryVolumeSize specifies the size limit for memory-backed volumes (required if UseMemoryVolumes is true)
                       Example: "2Gi"
                     type: string
+                  pvcSize:
+                    description: |-
+                      PVCSize specifies the size for persistent volume claims created for build workspaces
+                      Default: "8Gi"
+                    type: string
                   useMemoryVolumes:
                     description: UseMemoryVolumes determines whether to use memory-backed
                       volumes for build operations

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -42,8 +42,8 @@ spec:
               architecture:
                 description: Architecture specifies the target architecture
                 type: string
-              automativeOSBuildImage:
-                description: AutomativeOSBuildImage specifies the image to use for
+              automotiveImageBuilder:
+                description: AutomotiveImageBuilder specifies the image to use for
                   building
                 type: string
               distro:

--- a/config/samples/automotive_v1_automotivedev.yaml
+++ b/config/samples/automotive_v1_automotivedev.yaml
@@ -7,6 +7,7 @@ metadata:
         environment: development
     name: automotive-dev
 spec:
-    # buildConfig:
-    #     useMemoryVolumes: true
-    #     memoryVolumeSize: "8Gi"
+    buildConfig:
+        #     useMemoryVolumes: true
+        #     memoryVolumeSize: "8Gi"
+        pvcSize: "8Gi"

--- a/config/samples/automotive_v1_imagebuild.yaml
+++ b/config/samples/automotive_v1_imagebuild.yaml
@@ -17,7 +17,7 @@ spec:
   mode: "image"
   exportFormat: "qcow2"
   #storageClass: "lvms-vg1"  # use cluster default if not specified
-  automativeOSBuildImage: "quay.io/centos-sig-automotive/automotive-image-builder:latest"
+  automotiveImageBuilder: "quay.io/centos-sig-automotive/automotive-image-builder:1.0.0"
   manifestConfigMap: mpp
   serveArtifact: false
   serveExpiryHours: 24

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const AutomotiveImageBuilder = "quay.io/centos-sig-automotive/automotive-image-builder:1.0.0"
+
 // GeneratePushArtifactRegistryTask creates a Tekton Task for pushing artifacts to a registry
 func GeneratePushArtifactRegistryTask(namespace string) *tektonv1.Task {
 	return &tektonv1.Task{
@@ -140,12 +142,12 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *automotivev
 					Description: "Export format for the build",
 				},
 				{
-					Name:        "automotive-osbuild-image",
+					Name:        "automotive-image-builder",
 					Type:        tektonv1.ParamTypeString,
-					Description: "Automotive OSBuild container image to use",
+					Description: "automotive-image-builder container image to use",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
-						StringVal: "quay.io/centos-sig-automotive/automotive-image-builder:latest",
+						StringVal: AutomotiveImageBuilder,
 					},
 				},
 			},
@@ -181,7 +183,7 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *automotivev
 				},
 				{
 					Name:  "build-image",
-					Image: "$(params.automotive-osbuild-image)",
+					Image: "$(params.automotive-image-builder)",
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
 						SELinuxOptions: &corev1.SELinuxOptions{
@@ -344,11 +346,11 @@ func GenerateTektonPipeline(name, namespace string) *tektonv1.Pipeline {
 					},
 				},
 				{
-					Name: "automotive-osbuild-image",
+					Name: "automotive-image-builder",
 					Type: tektonv1.ParamTypeString,
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
-						StringVal: "quay.io/centos-sig-automotive/automotive-image-builder:latest",
+						StringVal: AutomotiveImageBuilder,
 					},
 					Description: "Automotive OSBuild image to use for building",
 				},

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -301,10 +301,10 @@ func (r *ImageBuildReconciler) createBuildTaskRun(ctx context.Context, imageBuil
 			},
 		},
 		{
-			Name: "automotive-osbuild-image",
+			Name: "automotive-image-builder",
 			Value: tektonv1.ParamValue{
 				Type:      tektonv1.ParamTypeString,
-				StringVal: imageBuild.Spec.AutomativeOSBuildImage,
+				StringVal: imageBuild.Spec.AutomotiveImageBuilder,
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying persistent volume claim size in build configuration, with a default of 8Gi.

- **Bug Fixes**
  - Corrected naming inconsistencies for the image builder container parameter and configuration fields across the application.
  - Updated default image builder container version from "latest" to "1.0.0".

- **Documentation**
  - Sample configuration files updated to reflect new field names and storage size options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->