### PR TITLE
enforce expiration

### DIFF
--- a/api/v1/automotivedev_types.go
+++ b/api/v1/automotivedev_types.go
@@ -50,6 +50,11 @@ type BuildConfig struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
 	// +optional
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
+
+	// ServeExpiryHours specifies how long to serve build artifacts before automatic cleanup
+	// Default: 24
+	// +optional
+	ServeExpiryHours int32 `json:"serveExpiryHours,omitempty"`
 }
 
 // AutomotiveDevStatus defines the observed state of AutomotiveDev

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -465,6 +465,17 @@ func createBuild(w http.ResponseWriter, r *http.Request) {
 		"automotive.sdv.cloud.redhat.com/target":       string(req.Target),
 		"automotive.sdv.cloud.redhat.com/architecture": string(req.Architecture),
 	}
+
+	serveExpiryHours := int32(24)
+	{
+		autoDev := &automotivev1.AutomotiveDev{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "automotive-dev", Namespace: namespace}, autoDev); err == nil {
+			if autoDev.Spec.BuildConfig != nil && autoDev.Spec.BuildConfig.ServeExpiryHours > 0 {
+				serveExpiryHours = autoDev.Spec.BuildConfig.ServeExpiryHours
+			}
+		}
+	}
+
 	imageBuild := &automotivev1.ImageBuild{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
@@ -479,7 +490,7 @@ func createBuild(w http.ResponseWriter, r *http.Request) {
 			Mode:                   string(req.Mode),
 			AutomotiveImageBuilder: req.AutomotiveImageBuilder,
 			ServeArtifact:          req.ServeArtifact,
-			ServeExpiryHours:       24,
+			ServeExpiryHours:       serveExpiryHours,
 			ManifestConfigMap:      cfgName,
 			InputFilesServer:       needsUpload,
 		},

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -66,7 +66,9 @@ func (r *ImageBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.handleUploadingState(ctx, imageBuild)
 	case "Building":
 		return r.handleBuildingState(ctx, imageBuild)
-	case "Completed", "Failed":
+	case "Completed":
+		return r.handleCompletedState(ctx, imageBuild)
+	case "Failed":
 		return ctrl.Result{}, nil
 	default:
 		log.Info("Unknown phase", "phase", imageBuild.Status.Phase)
@@ -85,7 +87,7 @@ func (r *ImageBuildReconciler) handleInitialState(ctx context.Context, imageBuil
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	if err := r.updateStatus(ctx, imageBuild, "Building", "Starting build process"); err != nil {
+	if err := r.updateStatus(ctx, imageBuild, "Building", "Build started"); err != nil {
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 	return ctrl.Result{Requeue: true}, nil
@@ -103,7 +105,7 @@ func (r *ImageBuildReconciler) handleUploadingState(ctx context.Context, imageBu
 		return ctrl.Result{RequeueAfter: time.Second * 5}, fmt.Errorf("failed to shutdown upload server: %w", err)
 	}
 
-	if err := r.updateStatus(ctx, imageBuild, "Building", "Starting build process"); err != nil {
+	if err := r.updateStatus(ctx, imageBuild, "Building", "Build started"); err != nil {
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 	return ctrl.Result{Requeue: true}, nil
@@ -151,6 +153,49 @@ func (r *ImageBuildReconciler) handleBuildingState(ctx context.Context, imageBui
 	}
 
 	return r.startNewBuild(ctx, imageBuild)
+}
+
+func (r *ImageBuildReconciler) handleCompletedState(ctx context.Context, imageBuild *automotivev1.ImageBuild) (ctrl.Result, error) {
+	if !imageBuild.Spec.ServeArtifact {
+		return ctrl.Result{}, nil
+	}
+
+	expiryHours := int32(24)
+	if imageBuild.Spec.ServeExpiryHours > 0 {
+		expiryHours = imageBuild.Spec.ServeExpiryHours
+	}
+
+	if imageBuild.Status.CompletionTime == nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	expiryAt := imageBuild.Status.CompletionTime.Time.Add(time.Duration(expiryHours) * time.Hour)
+	now := time.Now()
+	if now.Before(expiryAt) {
+		return ctrl.Result{RequeueAfter: time.Until(expiryAt)}, nil
+	}
+
+	svcName := fmt.Sprintf("%s-artifact-service", imageBuild.Name)
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: imageBuild.Namespace}}
+	_ = r.Delete(ctx, svc)
+
+	routeName := fmt.Sprintf("%s-artifacts", imageBuild.Name)
+	route := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: imageBuild.Namespace}}
+	_ = r.Delete(ctx, route)
+
+	podName := fmt.Sprintf("%s-artifact-pod", imageBuild.Name)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: imageBuild.Namespace}}
+	_ = r.Delete(ctx, pod)
+
+	fresh := &automotivev1.ImageBuild{}
+	if err := r.Get(ctx, types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}, fresh); err == nil {
+		patch := client.MergeFrom(fresh.DeepCopy())
+		fresh.Status.ArtifactURL = ""
+		fresh.Status.Message = "Artifact serving expired and resources cleaned up"
+		_ = r.Status().Patch(ctx, fresh, patch)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *ImageBuildReconciler) checkBuildProgress(ctx context.Context, imageBuild *automotivev1.ImageBuild) (ctrl.Result, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable artifact expiry via ServeExpiryHours (default 24h).
  * Automatic cleanup of artifact-serving resources after expiry; status clears artifact URL and shows cleanup message.
  * Dedicated handling for completed builds: waits for completion, serves until expiry, then cleans up; failed builds unchanged.
  * Status text refined: “Starting build process” → “Build started.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->