### PR TITLE
add requester

### DIFF
--- a/internal/buildapi/openapi.yaml
+++ b/internal/buildapi/openapi.yaml
@@ -243,6 +243,9 @@ components:
           type: string
         message:
           type: string
+        requestedBy:
+          type: string
+          nullable: true
         artifactURL:
           type: string
           nullable: true
@@ -254,6 +257,9 @@ components:
       properties:
         name:
           type: string
+        requestedBy:
+          type: string
+          nullable: true
     BuildTemplateResponse:
       allOf:
         - $ref: '#/components/schemas/BuildRequest'

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -97,6 +97,7 @@ type BuildResponse struct {
 	Name             string `json:"name"`
 	Phase            string `json:"phase"`
 	Message          string `json:"message"`
+	RequestedBy      string `json:"requestedBy,omitempty"`
 	ArtifactURL      string `json:"artifactURL,omitempty"`
 	ArtifactFileName string `json:"artifactFileName,omitempty"`
 	StartTime        string `json:"startTime,omitempty"`
@@ -108,6 +109,7 @@ type BuildListItem struct {
 	Name           string `json:"name"`
 	Phase          string `json:"phase"`
 	Message        string `json:"message"`
+	RequestedBy    string `json:"requestedBy,omitempty"`
 	CreatedAt      string `json:"createdAt"`
 	StartTime      string `json:"startTime,omitempty"`
 	CompletionTime string `json:"completionTime,omitempty"`

--- a/webui/src/components/BuildListPage.tsx
+++ b/webui/src/components/BuildListPage.tsx
@@ -33,6 +33,7 @@ interface BuildItem {
   name: string;
   phase: string;
   message: string;
+  requestedBy?: string;
   createdAt: string;
   startTime?: string;
   completionTime?: string;
@@ -42,6 +43,7 @@ interface BuildDetails {
   name: string;
   phase: string;
   message: string;
+  requestedBy?: string;
   artifactURL?: string;
   artifactFileName?: string;
   startTime?: string;
@@ -500,6 +502,7 @@ const BuildListPage: React.FC = () => {
               <Thead>
                 <Tr>
                   <Th>Name</Th>
+                  <Th>Requested By</Th>
                   <Th>Status</Th>
                   <Th>Message</Th>
                   <Th>Created</Th>
@@ -511,6 +514,7 @@ const BuildListPage: React.FC = () => {
                 {builds.map((build) => (
                   <Tr key={build.name}>
                     <Td>{build.name}</Td>
+                    <Td>{build.requestedBy || '-'}</Td>
                     <Td>
                       <Badge color={getPhaseVariant(build.phase)}>
                         {build.phase}
@@ -581,6 +585,8 @@ const BuildListPage: React.FC = () => {
                   <dl style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '8px 16px' }}>
                     <dt><strong>Name:</strong></dt>
                     <dd>{buildDetails.name}</dd>
+                    <dt><strong>Requested By:</strong></dt>
+                    <dd>{buildDetails.requestedBy || '-'}</dd>
                     <dt><strong>Status:</strong></dt>
                     <dd>
                       <Badge color={getPhaseVariant(buildDetails.phase)}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build API responses now include an optional requestedBy field (string, nullable) in list and detail payloads to indicate who initiated a build; backwards-compatible.
  * Web UI adds a “Requested By” column in the builds table and a “Requested By” row in build details, showing “-” when unavailable.
  * Requester identity is propagated so API and UI surface consistent provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->